### PR TITLE
Added Arduino compliant out of Range handling for the at() function

### DIFF
--- a/examples/at/at.ino
+++ b/examples/at/at.ino
@@ -1,0 +1,39 @@
+/**
+ * @file at.ino
+ * @author Alexander Tonn (https://github.com/AlexanderTonn)
+ * @brief This example shows the usage of ::at Operator
+ * ! If the inserted index is out of range, the program will return the value of the last index
+ * ! Code tested with Arduino MEGA2560
+ * @date 2024-01-05
+ */
+
+#include "Array.h"
+
+Array<uint32_t,12> test1 = {{34,32,66,34,35,23,44,78,56,240,2323,234}};
+const Array<uint32_t,10> test2 = {{1,7,3,7,35,23,44,78,56,240}};
+Array<float,5> test3 = {{1.45,425.0,234.9,234.4,567.4}};
+Array<float,8> test4 = {{false,false,true,true,false,true,true,true}};
+void setup()
+{
+  Serial.begin(9600);
+
+  // Try to Access an out of range index
+  Serial.println(test1.at(16));
+  Serial.println(test2.at(14));
+  Serial.println(test3.at(10));
+  Serial.println(test4.at(20));
+
+  Serial.println("########");
+
+  //Try to Access an in range index
+  Serial.println(test1.at(5));
+  Serial.println(test2.at(3));
+  Serial.println(test3.at(2));
+  Serial.println(test4.at(6));
+
+}
+
+void loop()
+{
+
+}

--- a/src/Array/ArrayDefinitions.h
+++ b/src/Array/ArrayDefinitions.h
@@ -66,14 +66,32 @@ template <typename T,
   size_t MAX_SIZE>
 const T & Array<T,MAX_SIZE>::at(size_t index) const
 {
-  return values_[index];
+  auto arraySize = sizeof(values_)/sizeof(values_[0]);
+
+  if(index < 0 || index >= arraySize)
+  {
+    Serial.println(" Array Index out of Range! Last valid Index will be returned.");
+
+    auto outOfRangeIndex = arraySize-1;
+    return values_[outOfRangeIndex]; 
+  }else 
+    return values_[index];
+
 }
 
 template <typename T,
   size_t MAX_SIZE>
 T & Array<T,MAX_SIZE>::at(size_t index)
 {
-  return values_[index];
+  auto arraySize = sizeof(values_)/sizeof(values_[0]);
+  if(index < 0 || index >= arraySize)
+  {
+    Serial.println(" Array Index out of Range! Last valid Index will be returned.");
+    
+    auto outOfRangeIndex = arraySize-1;
+    return values_[outOfRangeIndex]; 
+  }else 
+    return values_[index];
 }
 
 template <typename T,


### PR DESCRIPTION
Beforehand, I have to say that I appreciate it that you've created this library! 👍 

The big advantage of at() in the std::array lib is the detection of out of ranges indices. The function is throwing an exception if the inserted index is out of range of the array. 

* I added a small handling if an invalid index is passed to at(). If the UART Interface is started, the user will get an error message. 
* however in case of out of range the function will return the value of the last valid index 
* I also added an examples .ino file for showing the at() function with different data types.
* tested with arduino MEGA 2560 R3